### PR TITLE
PATHに"ffmpeg"が入ったフォルダーがあると無条件にそれを選択してしまう問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+
+# Logs
+log.txt
+
+# misc
+.DS_Store
+*.pem

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+Brotli==1.1.0
+certifi==2024.8.30
+charset-normalizer==3.3.2
+customtkinter==5.2.2
+darkdetect==0.8.0
+idna==3.10
+mutagen==1.47.0
+packaging==24.1
+pycryptodomex==3.20.0
+pyperclip==1.9.0
+requests==2.32.3
+urllib3==2.2.3
+websockets==13.0.1
+yt-dlp==2024.8.6


### PR DESCRIPTION
タイトルの通りです
## 概要
- PATHに`ffmpeg`が入ったフォルダーがあると、中に`ffmpeg.exe`, `ffplay.exe`, `ffprobe.exe`が無くてもそれが選択されてしまう場合がある
## 修正内容
- `ffmpeg.exe`を探しに行くように修正
- それでも見つからなかった場合に新規にダウンロードをするように
- ついでに`.gitignore`を追加
- ついでに必要ライブラリを列挙した`requirements.txt`を追加(`pip install -r requirements.txt`でインストール可能)